### PR TITLE
Add unit declarator to role declarations

### DIFF
--- a/nyi/Bio/Role/AnnotationCollection.pm6
+++ b/nyi/Bio/Role/AnnotationCollection.pm6
@@ -1,20 +1,19 @@
-role Bio::Role::AnnotationCollection;
+role Bio::Role::AnnotationCollection {
+    # rakudo doesn't handle typed arrays yet for return values, this can be done in the
 
-# rakudo doesn't handle typed arrays yet for return values, this can be done in the
-# 
+    our method get_all_Annotation_keys returns Array of Str  {...}
 
-our method get_all_Annotation_keys returns Array of Str  {...}
+    our method get_Annotations returns Array of Bio::Role::Annotation  (:@tagname? of Str) {...}
 
-our method get_Annotations returns Array of Bio::Role::Annotation  (:@tagname? of Str) {...}
+    our method get_nested_Annotations returns Array of Bio::Role::Annotation  (:@tagname? of Str) {...}
 
-our method get_nested_Annotations returns Array of Bio::Role::Annotation  (:@tagname? of Str) {...}
+    our method get_all_Annotations returns Array of Bio::Role::Annotation  (:@tagname? of Str) {...}
 
-our method get_all_Annotations returns Array of Bio::Role::Annotation  (:@tagname? of Str) {...}
+    our method get_num_Annotations returns Array  (Str :$tagname?) {...}
 
-our method get_num_Annotations returns Array  (Str :$tagname?) {...}
+    our method add_Annotation returns Bool  (Str :$tagname?, Bio::Role::Annotation *@annotations) {...}
 
-our method add_Annotation returns Bool  (Str :$tagname?, Bio::Role::Annotation *@annotations) {...}
+    our method remove_Annotations returns Bio::Role::Annotation  (:@tagname of Str) {...}
 
-our method remove_Annotations returns Bio::Role::Annotation  (:@tagname of Str) {...}
-
-our method flatten_Annotations returns Array of Bio::Role::Annotation  (:@tagname of Str) {...}
+    our method flatten_Annotations returns Array of Bio::Role::Annotation  (:@tagname of Str) {...}
+}

--- a/nyi/Bio/Role/Feature.pm6
+++ b/nyi/Bio/Role/Feature.pm6
@@ -1,83 +1,83 @@
-role Bio::Role::Feature;
+role Bio::Role::Feature {
+    # This is a generic role that describes and manipulates a specific region or
+    # segment that can be mapped to a start/end (and possibly strand) within another
+    # instance. In most cases the other instance will be a sequence, but it can also
+    # be used to describe a section in an alignment (such as a consensus structure),
+    # etc. If properly abused it could possibly be made to describe portions of a
+    # tree, where start and end denote start/end nodes.
 
-# This is a generic role that describes and manipulates a specific region or
-# segment that can be mapped to a start/end (and possibly strand) within another
-# instance. In most cases the other instance will be a sequence, but it can also
-# be used to describe a section in an alignment (such as a consensus structure),
-# etc. If properly abused it could possibly be made to describe portions of a
-# tree, where start and end denote start/end nodes.
+    # Modules using this role may or may not also be a FeatureHolder, and that
+    # these methods should not rely on that Role being implemented (or should at
+    # least take the above into consideration and DTRT)
 
-# Modules using this role may or may not also be a FeatureHolder, and that
-# these methods should not rely on that Role being implemented (or should at
-# least take the above into consideration and DTRT)
+    # display_name() could come in from Bio::Role::Describe, which also brings in
+    # description()
 
-# display_name() could come in from Bio::Role::Describe, which also brings in
-# description()
+    # Tags may or may not be mapped to a Bio::Role::AnnotationCollection (TBD)s
+    # we could implement it so that Bio::Role::AnnotationCollection does everything
+    # lazily; if you add a tag, the simple tag value is added (and not a heavier
+    # Bio::Role::Annotation) whereas if you add a Bio::Role::Annotation it is used
+    # instead.
 
-# Tags may or may not be mapped to a Bio::Role::AnnotationCollection (TBD)s
-# we could implement it so that Bio::Role::AnnotationCollection does everything
-# lazily; if you add a tag, the simple tag value is added (and not a heavier
-# Bio::Role::Annotation) whereas if you add a Bio::Role::Annotation it is used
-# instead.
+    qw(
+	display_name
+	primary_tag
+	source_tag
+	score
+	has_tag
+	add_tag_values
+	get_tag_values
+	get_tagset_values
+	get_all_tags
+	remove_tag
 
-qw(
-    display_name
-    primary_tag
-    source_tag
-    score
-    has_tag
-    add_tag_values
-    get_tag_values
-    get_tagset_values
-    get_all_tags
-    remove_tag
+	splice
+	attach_instance
+	get_trunc_instance
+	entire_instance
+	instance_id
 
-    splice
-    attach_instance
-    get_trunc_instance
-    entire_instance
-    instance_id
-    
-    location
-    primary_id
-    set_attributes
-);
+	location
+	primary_id
+	set_attributes
+    );
 
-# seq-specific, should delegate to the generic method, which just curries
-# trunc() (or whatever method name we intend on using for getting a slice of an
-# object)
+    # seq-specific, should delegate to the generic method, which just curries
+    # trunc() (or whatever method name we intend on using for getting a slice of an
+    # object)
 
-# the call to trunc() should allow for optional recursive calls to contained
-# objects
+    # the call to trunc() should allow for optional recursive calls to contained
+    # objects
 
-# subrole-specific attributes should be mappable to the tag system above (such
-# as frame() below), primarily so that persisting the data is done in a
-# consistent way, using the most generic Role vs the most specific one
+    # subrole-specific attributes should be mappable to the tag system above (such
+    # as frame() below), primarily so that persisting the data is done in a
+    # consistent way, using the most generic Role vs the most specific one
 
-# seq-specific
+    # seq-specific
 
-qw(
-    spliced_Seq
-    get_Seq
-    attach_Seq
-    entire_Seq
-    frame
-);
+    qw(
+	spliced_Seq
+	get_Seq
+	attach_Seq
+	entire_Seq
+	frame
+    );
 
-# alignment-specific
+    # alignment-specific
 
-qw(
-    spliced_Aln
-    get_Aln
-    attach_Aln
-    entire_Aln
-);
+    qw(
+	spliced_Aln
+	get_Aln
+	attach_Aln
+	entire_Aln
+    );
 
-# Tree-specific
+    # Tree-specific
 
-qw(
-    spliced_Tree
-    get_Tree
-    attach_Tree
-    entire_Tree
-);
+    qw(
+	spliced_Tree
+	get_Tree
+	attach_Tree
+	entire_Tree
+    );
+}

--- a/nyi/Bio/Role/FeatureCollection.pm6
+++ b/nyi/Bio/Role/FeatureCollection.pm6
@@ -1,48 +1,47 @@
-role Bio::Role::FeatureCollection;
+role Bio::Role::FeatureCollection {
+    # this role describes methods for accessing Features for a specific instance.
+    # implementing classes are considered to contain Bio::Role::Features of some
+    # type.
 
-# this role describes methods for accessing Features for a specific instance.
-# implementing classes are considered to contain Bio::Role::Features of some
-# type.
+    # Wondering if this and FeatureHolder should be combined for
+    # consistency. For instance, it would be nice to have binning available for
+    # grabbing features by location.  May be redundant for subfeatures...
 
-# Wondering if this and FeatureHolder should be combined for
-# consistency. For instance, it would be nice to have binning available for
-# grabbing features by location.  May be redundant for subfeatures...
+    # Would be nice to have iterative methods. Built-in support for Iterators and
+    # laziness are planned for perl6 (Iterators are to be a built-in Role):
 
-# Would be nice to have iterative methods. Built-in support for Iterators and
-# laziness are planned for perl6 (Iterators are to be a built-in Role):
+    # http://feather.perl6.nl/syn/S07.html
 
-# http://feather.perl6.nl/syn/S07.html
+    # Also note that having Grammars that we can attach various Actions to may
+    # help this quite a bit.  We'll see as the spec develops...
 
-# Also note that having Grammars that we can attach various Actions to may
-# help this quite a bit.  We'll see as the spec develops...
+    has Int $.min_bin;
+    has Int $.max_bin;
 
-has Int $.min_bin;
-has Int $.max_bin;
+    our Array of Bio::Role::Feature method get_Features
+    (
+	:$range? of any(Range | Bio::Role::Range),  # for grabbing features in a range
+	Int :$start?,
+	Int :$end?,
+	Int :$strand?,
+	Bool :$contains?,
+	Str :$strand_test?,
+    )
+    {...}
 
-our Array of Bio::Role::Feature method get_Features
-(
-    :$range? of any(Range | Bio::Role::Range),  # for grabbing features in a range
-    Int :$start?,
-    Int :$end?,
-    Int :$strand?,
-    Bool :$contains?,
-    Str :$strand_test?,
-)
-{...}
+    our Bool method add_Features (:@features of Bio::Role::Feature)
+    {...}
 
-our Bool method add_Features (:@features of Bio::Role::Feature)
-{...}
+    our Array of Bio::Role::Features remove_Features
+    (
+	:@features? of Bio::Role::Feature,
+	:$range? of any(Range | Bio::Role::Range)
+    )
+    {...}
 
-our Array of Bio::Role::Features remove_Features
-(
-    :@features? of Bio::Role::Feature,
-    :$range? of any(Range | Bio::Role::Range)
-)
-{...}
+    our Int method feature_count
+    {...}
 
-our Int method feature_count
-{...}
-
-our Array of Bio::Role::Feature method get_all_Features
-{...}
-
+    our Array of Bio::Role::Feature method get_all_Features
+    {...}
+}

--- a/nyi/Bio/Role/Location.pm6
+++ b/nyi/Bio/Role/Location.pm6
@@ -1,55 +1,56 @@
-role Bio::Role::Location;
-#probably add range in time
-#does Bio::Role::Range;
+role Bio::Role::Location {
+    #probably add range in time
+    #does Bio::Role::Range;
 
-has Str $.seq_id is rw;
-has Bool $.is_remote is rw = False;
+    has Str $.seq_id is rw;
+    has Bool $.is_remote is rw = False;
 
-#will be type of : Location_Pos_Type
-has Str $.start_pos_type is rw = 'EXACT';
-has Str $.end_pos_type is rw = 'EXACT';
+    #will be type of : Location_Pos_Type
+    has Str $.start_pos_type is rw = 'EXACT';
+    has Str $.end_pos_type is rw = 'EXACT';
 
-#need to be Location_Type obj
-has Str $.location_type is rw = 'EXACT';
-
-
-
-#need to be Sequence_strand Obj
-has Str $!strand is rw = 0;
+    #need to be Location_Type obj
+    has Str $.location_type is rw = 'EXACT';
 
 
-multi method flip_strand() {
-    $!strand = $!strand * -1;
+
+    #need to be Sequence_strand Obj
+    has Str $!strand is rw = 0;
+
+
+    multi method flip_strand() {
+	$!strand = $!strand * -1;
+    }
+
+    multi method strand(){
+	return $!strand;
+    }
+
+    multi method strand($value){
+	$!strand=$value;
+    }
+
+    multi method each_Location($order?) {
+	return self;
+    }
+
+
+    # below should be the interface
+    # # thinking the below could possibly be flattened into Location or Range
+    # # via curry/assuming?
+    # probably not doing CoordinatePolicy
+    # has Bio::Role::CoordinatePolicy $.coordinate_policy     is rw;
+
+    # not sure how I'm going to handle this yet
+    # our Int method min_start {...}
+    # our Int method max_start {...}
+    # our Int method min_end {...}
+    # our Int method max_end {...}
+    # our Str method start_pos_type {...}
+    # our Str method end_pos_type {...}
+    # our method flip_strand {...}
+
+    # our Str to_string {...}
+    # our Bio::Role::Location next_Location {...}
+    # our Bool method is_valid {...}
 }
-
-multi method strand(){
-    return $!strand;
-}
-
-multi method strand($value){
-    $!strand=$value;
-}
-
-multi method each_Location($order?) {
-    return self;
-}
-
-
-# below should be the interface
-# # thinking the below could possibly be flattened into Location or Range
-# # via curry/assuming?
-# probably not doing CoordinatePolicy
-# has Bio::Role::CoordinatePolicy $.coordinate_policy     is rw;
-
-# not sure how I'm going to handle this yet
-# our Int method min_start {...}
-# our Int method max_start {...}
-# our Int method min_end {...}
-# our Int method max_end {...}
-# our Str method start_pos_type {...}
-# our Str method end_pos_type {...}
-# our method flip_strand {...}
-
-# our Str to_string {...}
-# our Bio::Role::Location next_Location {...}
-# our Bool method is_valid {...}

--- a/nyi/Bio/Role/RichSeq.pm6
+++ b/nyi/Bio/Role/RichSeq.pm6
@@ -1,47 +1,46 @@
-role Bio::Role::RichSeq;
+role Bio::Role::RichSeq {
+    # wondering if this should be simplified (see comments) and merged with
+    # Bio::Role::Seq...
 
-# wondering if this should be simplified (see comments) and merged with
-# Bio::Role::Seq...
+    has Str $.division              is rw;
+    has Str $.molecule              is rw;  # this is pretty close to moltype, which is deprecated...
 
-has Str $.division              is rw;
-has Str $.molecule              is rw;  # this is pretty close to moltype, which is deprecated...
+    # the next two may be removed based on input
+    has Str $.pid                   is rw;  # is this the same as .primary_id? (Bio::Role::Identify)
+    has Str $.seq_version           is rw;  # is this the same as .version?    (Bio::Role::Identify)
 
-# the next two may be removed based on input
-has Str $.pid                   is rw;  # is this the same as .primary_id? (Bio::Role::Identify)
-has Str $.seq_version           is rw;  # is this the same as .version?    (Bio::Role::Identify)
+    # These grab the (stringified) data from the annotation collection using the
+    # corresponding type (the tag name). They're really convenience methods for
+    # add_Annotation('foo', @foo) and get_Annotations('foo'), so we can probably
+    # decide whether or not it's necessary to even have a RichSeq role as anything
+    # more than a convenience
 
-# These grab the (stringified) data from the annotation collection using the
-# corresponding type (the tag name). They're really convenience methods for
-# add_Annotation('foo', @foo) and get_Annotations('foo'), so we can probably
-# decide whether or not it's necessary to even have a RichSeq role as anything
-# more than a convenience
+    # TODO: typed arrays/hashes are not implemented in rakudo
 
-# TODO: typed arrays/hashes are not implemented in rakudo
+    our Bool method add_secondary_accessions (
+	Str :$type = 'secondary_accession', Str *@accession
+    )
+    {...}
+    our Array of Str method get_secondary_accessions (
+	Str :$type = 'secondary_accession'
+    )
+    {...}
 
-our Bool method add_secondary_accessions (
-    Str :$type = 'secondary_accession', Str *@accession
-)
-{...}
-our Array of Str method get_secondary_accessions (
-    Str :$type = 'secondary_accession'
-)
-{...}
+    our Bool method add_dates (
+	Str :$type = 'date_changed', Str *@dates
+    )
+    {...}
+    our Array of Str method get_dates (
+	Str :$type = 'date_changed', Str :$date
+    )
+    {...}
 
-our Bool method add_dates (
-    Str :$type = 'date_changed', Str *@dates
-)
-{...}
-our Array of Str method get_dates (
-    Str :$type = 'date_changed', Str :$date
-)
-{...}
-
-our Bool method add_keywords (
-    Str :$type = 'keyword', *@keywords,
-)
-{...}
-our Array of Str method get_keywords (
-    Str :$type = 'keyword', Str :$keyword
-)
-{...}
-
+    our Bool method add_keywords (
+	Str :$type = 'keyword', *@keywords,
+    )
+    {...}
+    our Array of Str method get_keywords (
+	Str :$type = 'keyword', Str :$keyword
+    )
+    {...}
+}


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class`, `role` or `grammar` declarations (unless it uses a
block).  Code still using the old blockless semicolon form will throw a
warning. This commit stops the warning from appearing in the new Rakudo.

I noticed that you'd updated some of the other unit-related issues and had done so by using the block form of the role statement, thus I've updated the remaining files similarly.