### PR TITLE
Fix Outdated Stuff

### DIFF
--- a/lib/Bio/Role/Pluggable.pm6
+++ b/lib/Bio/Role/Pluggable.pm6
@@ -14,7 +14,7 @@ role Bio::Role::Pluggable[Str $pd] # does Pluggable
     method plugins(:$module) {
         my @list;
         # if a specific module is passed, check that namespace, otherwise use current class name    
-        my $class = "{$module:defined ?? $module !! ::?CLASS.^name}";
+        my $class = "{$module.defined ?? $module !! ::?CLASS.^name}";
         # convert to path, probably should use spec here
         $class   ~~ s:g/'::'/\//;
         

--- a/nyi/t/Factory/FTLocationFactory.t
+++ b/nyi/t/Factory/FTLocationFactory.t
@@ -1,9 +1,5 @@
 use v6;
-
-BEGIN {
-    @*INC.push('./lib');
-}
-
+use lib 'lib';
 use Test;
 plan 268;
 eval_lives_ok 'use Bio::Factory::FTLocationFactory', 'Can use Bio::Factory::FTLocationFactory';

--- a/nyi/t/LiveSeq/Mutation.t
+++ b/nyi/t/LiveSeq/Mutation.t
@@ -1,8 +1,5 @@
 use v6;
-BEGIN {
-    @*INC.push('./lib');
-}
-
+use lib 'lib';
 use Test;
 plan 44;
 eval_lives_ok 'use Bio::LiveSeq::Mutation', 'Can use Bio::LiveSeq::Mutation';

--- a/nyi/t/Location.t
+++ b/nyi/t/Location.t
@@ -1,8 +1,6 @@
 use v6;
 
-BEGIN {
-    @*INC.push('./lib');
-}
+use lib 'lib';
 
 use Test;
 #plan 103;

--- a/nyi/t/Location/Simple.t
+++ b/nyi/t/Location/Simple.t
@@ -1,8 +1,5 @@
 use v6;
-
-BEGIN {
-    @*INC.push('./lib');
-}
+use lib 'lib';
 use Test;
 plan 70;
 eval_lives_ok 'use Bio::Role::Location::Simple', 'Can use Bio::Role::Location::Simple';

--- a/nyi/t/SeqFeature/Lite.t
+++ b/nyi/t/SeqFeature/Lite.t
@@ -1,7 +1,5 @@
 use v6;
-BEGIN {
-    @*INC.push('./lib');
-}
+use lib 'lib';
 
 use Test;
 plan 75;

--- a/nyi/t/SeqIO/genbank.t
+++ b/nyi/t/SeqIO/genbank.t
@@ -3,10 +3,7 @@ use Test;
 #plan 249;
 plan 1;
 
-BEGIN {
-    @*INC.push('lib');
-    @*INC.push('blib');    
-}
+use lib <lib blib>;
 #probably not final module path
 #eval_lives_ok 'use Bio::SeqIO::Genbank', 'Can use Bio::SeqIO::Genbank';
 eval_lives_ok 'use Bio::SeqIO', 'Can use Bio::SeqIO';


### PR DESCRIPTION
This fixes some stuff that changed in most recent Rakudo.

Note, `@*INC` is no longer available, I changed what I could, but I don't know how to convert the `for (@*INC)` bit in `lib/Bio/Role/Pluggable.pm6`.