### PR TITLE
Add missing use statements in test file

### DIFF
--- a/t/PrimarySeq.t
+++ b/t/PrimarySeq.t
@@ -7,6 +7,7 @@ use lib './lib';
 eval-lives-ok 'use Bio::PrimarySeq', 'Can use Bio::PrimarySeq';
 
 use Bio::PrimarySeq;
+use Bio::Type::Sequence;
 
 my $seq = Bio::PrimarySeq.new(
     seq                     => 'TTGGTGGCGTCAACT',

--- a/t/SeqIO.t
+++ b/t/SeqIO.t
@@ -5,6 +5,7 @@ use lib './lib';
 use Test;
 
 use Bio::SeqIO;
+use Bio::SeqIO::fasta;
 
 ok(1);
 


### PR DESCRIPTION
The design of Perl 6 requires that use statements only have effect in a
lexical scope. Otherwise it's impossible to use different (versions of)
modules sharing a name in different parts of a program.

This means essentially that we need to explicitly use all modules we need
in a scope.

See https://gist.github.com/niner/70f7b46eefb7e22af78d896bea11efeb for
further information.