### PR TITLE
Use SPDX identifier in license field of META.info

### DIFF
--- a/META.info
+++ b/META.info
@@ -2,6 +2,7 @@
     "tags" : [ "Bio", "Biology", "Science", "Bioinformatics", "Grammar" ],
     "perl" : "6.c",
     "name" : "BioPerl6",
+    "license" : "Artistic-2.0",
     "version" : "0.0.1",
     "description" : "Collection of Bioinformatics classes, roles, and modules",
     "authors" : "git:cjfields",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license